### PR TITLE
More help flags

### DIFF
--- a/bin/fancy_audio
+++ b/bin/fancy_audio
@@ -33,7 +33,7 @@ def execute
   first = ARGV[0]
   second = ARGV[1]
 
-  if first == '--h' && ARGV.size == 1
+  if ['--h', '--help', '-h', '-?'].include?(first) && ARGV.size == 1
     print_help
 
   elsif first == '--all'

--- a/spec/fancy_audio_spec.rb
+++ b/spec/fancy_audio_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe :FancyAudio do
 
-  before(:each) do
+  after(:each) do
    remove_pictures_from_songs
   end
 


### PR DESCRIPTION
Command-line flags to get help are commonly a single dash for a single-character flag (e.g. `-h`) or a double-dash for a full word (e.g. `--help`).  `-?` is also found in some programs.  We should respond to all of those, and the `--h` that already exists, to give users a better chance to get help.

The main file does not currently have unit tests.  Demonstrations of the new flags:

`--help`:
```plain
heaven:~/src/fancy_audio$ ./bin/fancy_audio --help
    fancy_audio --all /path/to/songs image_file  #=> attach image_file to all audio_files.(default songs path is current directory)
    fancy_audio audio_file image_file  #=> attach image_file to audio_file
    fancy_audio                        #=> attach all audio and images with same name(default current dir) e.g song1.mp3 and song1.jpg
    fancy_audio path/to/files          #=> attach all audio and images with same name(cutom path to dir) e.g song1.mp3 and song1.jpg
    fancy_audio --h                    #=> to print help

    To see a demo visit - http://www.singhajit.com/fancyaudio-gem-to-add-album-cover-to-audio-file/
```
`-h`:
```plain
heaven:~/src/fancy_audio$ ./bin/fancy_audio -h
    fancy_audio --all /path/to/songs image_file  #=> attach image_file to all audio_files.(default songs path is current directory)
    fancy_audio audio_file image_file  #=> attach image_file to audio_file
    fancy_audio                        #=> attach all audio and images with same name(default current dir) e.g song1.mp3 and song1.jpg
    fancy_audio path/to/files          #=> attach all audio and images with same name(cutom path to dir) e.g song1.mp3 and song1.jpg
    fancy_audio --h                    #=> to print help

    To see a demo visit - http://www.singhajit.com/fancyaudio-gem-to-add-album-cover-to-audio-file/
```
`-?`:
```plain
heaven:~/src/fancy_audio$ ./bin/fancy_audio -?
    fancy_audio --all /path/to/songs image_file  #=> attach image_file to all audio_files.(default songs path is current directory)
    fancy_audio audio_file image_file  #=> attach image_file to audio_file
    fancy_audio                        #=> attach all audio and images with same name(default current dir) e.g song1.mp3 and song1.jpg
    fancy_audio path/to/files          #=> attach all audio and images with same name(cutom path to dir) e.g song1.mp3 and song1.jpg
    fancy_audio --h                    #=> to print help

    To see a demo visit - http://www.singhajit.com/fancyaudio-gem-to-add-album-cover-to-audio-file/
```
Original flag still works:
```plain
heaven:~/src/fancy_audio$ ./bin/fancy_audio --h
    fancy_audio --all /path/to/songs image_file  #=> attach image_file to all audio_files.(default songs path is current directory)
    fancy_audio audio_file image_file  #=> attach image_file to audio_file
    fancy_audio                        #=> attach all audio and images with same name(default current dir) e.g song1.mp3 and song1.jpg
    fancy_audio path/to/files          #=> attach all audio and images with same name(cutom path to dir) e.g song1.mp3 and song1.jpg
    fancy_audio --h                    #=> to print help

    To see a demo visit - http://www.singhajit.com/fancyaudio-gem-to-add-album-cover-to-audio-file/
```
Program still does its normal function:
```plain
heaven:~/src/fancy_audio$ ./bin/fancy_audio spec/resources/song1.mp3 spec/resources/song1.jpg 
heaven:~/src/fancy_audio$ git status
On branch more-help-flags
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   spec/resources/song1.mp3

no changes added to commit (use "git add" and/or "git commit -a")
```
Also a commit here to clean up tests after completion, so nobody accidentally commits the changed test resources.